### PR TITLE
Fixing the bug where the results. The previous fix I implemented was …

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,59 @@
+# This workflow automates two key tasks:
+# 1. On push to the main branch: It automatically copies the main HTML calculator to docs/index.html and commits the change.
+#    This keeps your GitHub Pages site up-to-date without any manual work.
+# 2. On new tag push (e.g., v1.0.0): It creates a new GitHub Release and attaches a .zip and .tar.gz archive 
+#    containing the calculator and the shell script for users to download.
+
+name: Release and Deploy
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  # This job runs ONLY on pushes to the main branch
+  sync-docs:
+    # The 'if' condition ensures this job doesn't run for tag pushes
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Copy calculator to docs/index.html
+        run: cp prometheus-sizing-calculator.html docs/index.html
+
+      - name: Commit and push if changed
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "Automated: Sync calculator with docs/index.html"
+          file_pattern: docs/index.html
+
+  # This job runs ONLY when a new tag is pushed
+  create-release:
+    # The 'if' condition ensures this job only runs for tag pushes
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # This permission is required to create a release
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Archive release files
+        run: |
+          zip prometheus-tools.zip prometheus-sizing-calculator.html prometheus-sizing-calculator.sh
+          tar -czvf prometheus-tools.tar.gz prometheus-sizing-calculator.html prometheus-sizing-calculator.sh
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          # This will create a release with the tag name (e.g., v1.0.1)
+          # It will automatically generate release notes based on your commits.
+          files: |
+            prometheus-tools.zip
+            prometheus-tools.tar.gz
+

--- a/prometheus-sizing-calculator.html
+++ b/prometheus-sizing-calculator.html
@@ -33,6 +33,10 @@
         .transition-all {
             transition: all 0.3s ease-in-out;
         }
+        /* Style for breaking long numbers */
+        .break-all {
+            word-break: break-all;
+        }
     </style>
 </head>
 <body class="bg-gray-50 text-gray-800">
@@ -43,6 +47,16 @@
         <header class="text-center mb-8">
             <h1 class="text-3xl sm:text-4xl font-bold text-gray-900">Prometheus Sizing Calculator for YugabyteDB Anywhere</h1>
             <p class="mt-2 text-md text-gray-600">Interactively estimate memory, disk, and CPU requirements for your YugabyteDB Anywhere Node which runs Prometheus, YB-Platform and Postgres service.</p>
+            <p class="mt-1 text-sm text-gray-500">For more information, visit: <a href="https://support.yugabyte.com/hc/en-us/articles/38092646336909-How-to-Estimate-Prometheus-Resource-Requirements-for-YugabyteDB-Anywhere" class="text-primary-orange hover:underline">Support Article</a></p>
+            <p class="mt-1 text-sm text-gray-500">
+              <a href="https://github.com/yugabyte/prometheus-sizing-calculator" class="inline-flex items-center text-primary-orange hover:underline">
+                <!-- GitHub SVG Icon -->
+                <svg class="w-4 h-4 mr-1 inline-block" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M12 0C5.37 0 0 5.373 0 12c0 5.303 3.438 9.8 8.205 11.387.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.726-4.042-1.61-4.042-1.61-.546-1.387-1.333-1.756-1.333-1.756-1.09-.745.083-.729.083-.729 1.205.085 1.84 1.237 1.84 1.237 1.07 1.834 2.807 1.304 3.492.997.108-.775.418-1.305.762-1.605-2.665-.304-5.466-1.334-5.466-5.931 0-1.31.468-2.381 1.236-3.221-.124-.303-.535-1.523.117-3.176 0 0 1.008-.322 3.3 1.23a11.52 11.52 0 013.003-.404c1.02.005 2.047.138 3.003.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.873.119 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.803 5.625-5.475 5.921.43.372.823 1.104.823 2.227 0 1.607-.015 2.903-.015 3.297 0 .321.218.694.825.576C20.565 21.796 24 17.299 24 12c0-6.627-5.373-12-12-12z"/>
+                </svg>
+                yugabyte/prometheus-sizing-calculator
+              </a>
+            </p>
         </header>
 
         <div class="grid grid-cols-1 lg:grid-cols-3 gap-8">
@@ -80,18 +94,16 @@
 
                 <!-- Live Formula Breakdown -->
                 <div id="live-formula-view" class="hidden bg-white p-6 rounded-xl shadow-md border border-gray-200">
-                    <h2 id="live-universe-name" class="text-xl font-bold text-primary-orange mb-4">Universe Name</h2>
+                    <h2 id="live-universe-name" class="text-xl font-bold text-primary-orange mb-4">Live Breakdown</h2>
                     <div class="space-y-4 text-sm">
                         <div>
-                            <p class="font-semibold text-gray-800">Total Metrics</p>
-                            <p id="live-metrics-formula" class="font-mono text-gray-600 bg-gray-50 p-2 rounded-md mt-1"></p>
-                        </div>
-                        <div>
-                            <p class="font-semibold text-gray-800">Memory</p>
-                            <p id="live-memory-formula" class="font-mono text-gray-600 bg-gray-50 p-2 rounded-md mt-1"></p>
+                            <p class="font-semibold text-gray-800">Isolated Estimate for this Universe</p>
+                            <p id="live-metrics-formula" class="font-mono text-gray-600 bg-gray-50 p-2 rounded-md mt-1 break-all"></p>
+                            <p class="text-xs text-gray-500 mt-2">Note: This is a preview for this universe alone. The final total on the right uses a combined calculation for higher accuracy.</p>
                         </div>
                     </div>
                 </div>
+
 
                 <!-- Universe List Card -->
                 <div class="bg-white p-6 rounded-xl shadow-md border border-gray-200">
@@ -106,18 +118,18 @@
             <!-- Right Column: Summary -->
             <div class="lg:col-span-1">
                 <div class="bg-grayscale-black text-white p-6 rounded-xl shadow-lg sticky top-8">
-                    <h2 class="text-xl font-semibold mb-4 text-center border-b border-primary-orange/30 pb-3">Estimated Requirements</h2>
+                    <h2 class="text-xl font-semibold mb-4 text-center border-b border-primary-orange/30 pb-3">Total Deployment Estimate</h2>
                     
                     <div class="text-center mb-6">
                         <p class="text-sm text-gray-400 uppercase tracking-wider">Total Metrics</p>
-                        <p id="total-metrics" class="text-2xl sm:text-3xl lg:text-4xl font-bold text-primary-orange">0</p>
+                        <p id="total-metrics" class="text-2xl sm:text-3xl lg:text-4xl font-bold text-primary-orange break-all">0</p>
                     </div>
 
                     <div class="space-y-5">
                         <div class="flex items-center justify-between p-4 bg-white/10 rounded-lg">
                             <div>
                                 <p class="text-sm text-gray-300">Memory</p>
-                                <p id="memory-gb" class="text-xl sm:text-2xl font-semibold">0.00 GB</p>
+                                <p id="memory-gb" class="text-xl sm:text-2xl font-semibold break-all">0.00 GB</p>
                             </div>
                             <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8 text-primary-orange" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                                 <rect x="3" y="8" width="18" height="8" rx="1" />
@@ -127,7 +139,7 @@
                         <div class="flex items-center justify-between p-4 bg-white/10 rounded-lg">
                             <div>
                                 <p class="text-sm text-gray-300">Disk</p>
-                                <p id="disk-gb" class="text-xl sm:text-2xl font-semibold">0.00 GB</p>
+                                <p id="disk-gb" class="text-xl sm:text-2xl font-semibold break-all">0.00 GB</p>
                             </div>
                            <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8 text-primary-orange" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                                 <rect x="5" y="4" width="14" height="16" rx="2" />
@@ -138,7 +150,7 @@
                         <div class="flex items-center justify-between p-4 bg-white/10 rounded-lg">
                             <div>
                                 <p class="text-sm text-gray-300">CPU</p>
-                                <p id="cpu-cores" class="text-xl sm:text-2xl font-semibold">0.00 Cores</p>
+                                <p id="cpu-cores" class="text-xl sm:text-2xl font-semibold break-all">0.00 Cores</p>
                             </div>
                             <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8 text-primary-orange" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                                <rect x="5" y="5" width="14" height="14" rx="1" />
@@ -160,9 +172,9 @@
                     <!-- Total Metrics Logic -->
                     <div>
                         <h3 class="font-semibold text-primary-orange">Total Metrics</h3>
-                        <p class="text-sm text-gray-600 mt-1 mb-2">The metrics for a single universe are calculated as:</p>
-                        <div class="bg-gray-50 border-l-4 border-primary-orange p-4 rounded-md">
-                            <code class="block w-full bg-transparent text-gray-800 text-sm font-mono">Universe Metrics = (60 * Tables + 9000) * Nodes</code>
+                        <p class="text-sm text-gray-600 mt-1 mb-2">Metrics are calculated based on the sum of all tables and nodes across all configured universes to ensure consistency.</p>
+                        <div class="bg-gray-50 border-l-4 border-primary-orange p-4 rounded-md space-y-2">
+                             <code class="block w-full bg-transparent text-gray-800 text-sm font-mono">Total Metrics = (60 * Σ(Tables) + 9000) * Σ(Nodes)</code>
                         </div>
                     </div>
 
@@ -225,32 +237,17 @@
         const diskGbEl = document.getElementById('disk-gb');
         const cpuCoresEl = document.getElementById('cpu-cores');
 
-        // Live Formula View Elements
         const liveFormulaViewEl = document.getElementById('live-formula-view');
         const liveUniverseNameEl = document.getElementById('live-universe-name');
         const liveMetricsFormulaEl = document.getElementById('live-metrics-formula');
-        const liveMemoryFormulaEl = document.getElementById('live-memory-formula');
-
+        
         // --- State Management ---
         let universes = [];
 
         // --- Core Logic ---
-
-        /**
-         * Calculates metrics for a single universe based on tables and nodes.
-         * @param {number} tables - The number of tables.
-         * @param {number} nodes - The number of nodes.
-         * @returns {bigint} The calculated metrics for the universe.
-         */
-        function calculateUniverseMetrics(tables, nodes) {
-            return (BigInt(60) * BigInt(tables) + BigInt(9000)) * BigInt(nodes);
-        }
-
+        
         /**
          * Formats a potentially very large number for display.
-         * @param {number | bigint} num - The number to format.
-         * @param {number} threshold - The number above which to use scientific notation.
-         * @returns {string} The formatted number string.
          */
         function formatLargeNumber(num, threshold = 1e15) {
             const numAsNumber = Number(num);
@@ -261,11 +258,23 @@
         }
         
         /**
-         * Recalculates the total requirements based on the current list of universes.
+         * Recalculates the total requirements based on the configured universes AND the live inputs.
          */
         function calculateTotalRequirements() {
-            const total_metrics = universes.reduce((sum, u) => sum + u.metrics, BigInt(0));
+            // 1. Get totals from the configured universe list
+            let totalTables = universes.reduce((sum, u) => sum + u.tables, 0);
+            let totalNodes = universes.reduce((sum, u) => sum + u.nodes, 0);
+
+            // 2. Add numbers from the live input fields
+            const liveTables = parseInt(tablesInput.value, 10) || 0;
+            const liveNodes = parseInt(nodesInput.value, 10) || 0;
+            totalTables += liveTables;
+            totalNodes += liveNodes;
             
+            // 3. Apply the final, consistent formula
+            const total_metrics = (BigInt(60) * BigInt(totalTables) + BigInt(9000)) * BigInt(totalNodes);
+            
+            // 4. Calculate final resource requirements
             const memory_per_metric = (total_metrics > 1000000) ? BigInt(10) : BigInt(30);
             const memory_kb = total_metrics * memory_per_metric;
             const memory_gb = Number(memory_kb) / 1024 / 1024;
@@ -275,6 +284,7 @@
 
             const cpu = Number(total_metrics) / 1000000;
 
+            // 5. Update the UI
             totalMetricsEl.textContent = formatLargeNumber(total_metrics);
             memoryGbEl.textContent = `${formatLargeNumber(memory_gb, 1e6)} GB`;
             diskGbEl.textContent = `${formatLargeNumber(disk_gb, 1e6)} GB`;
@@ -282,32 +292,7 @@
         }
 
         /**
-         * Updates the live formula view based on current input values.
-         */
-        function updateLiveFormulaView() {
-            const name = nameInput.value.trim();
-            const tables = parseInt(tablesInput.value, 10);
-            const nodes = parseInt(nodesInput.value, 10);
-
-            if (isNaN(tables) || isNaN(nodes) || tables < 0 || nodes < 0) {
-                liveFormulaViewEl.classList.add('hidden');
-                return;
-            }
-            
-            liveFormulaViewEl.classList.remove('hidden');
-            liveUniverseNameEl.textContent = name || "Live Breakdown";
-
-            const live_metrics = calculateUniverseMetrics(tables, nodes);
-            const memory_per_metric = (live_metrics > 1000000) ? BigInt(10) : BigInt(30);
-            const memory_kb = live_metrics * memory_per_metric;
-            const memory_gb = Number(memory_kb) / 1024 / 1024;
-
-            liveMetricsFormulaEl.textContent = `(60 * ${tables.toLocaleString()} Tables + 9000) * ${nodes.toLocaleString()} Nodes = ${formatLargeNumber(live_metrics)} metrics`;
-            liveMemoryFormulaEl.textContent = `(${formatLargeNumber(live_metrics)} metrics * ${memory_per_metric} bytes/metric) / 1024^2 = ${formatLargeNumber(memory_gb)} GB`;
-        }
-
-        /**
-         * Renders the list of universes in the DOM.
+         * Renders the list of configured universes in the DOM.
          */
         function renderUniverses() {
             universesList.innerHTML = '';
@@ -321,7 +306,7 @@
                         <div>
                             <p class="font-semibold text-gray-800">${universe.name}</p>
                             <p class="text-sm text-gray-600">
-                                Tables: ${Number(universe.tables).toLocaleString()} | Nodes: ${Number(universe.nodes).toLocaleString()} → Metrics: <span class="font-medium">${Number(universe.metrics).toLocaleString()}</span>
+                                Tables: ${universe.tables.toLocaleString()} | Nodes: ${universe.nodes.toLocaleString()}
                             </p>
                         </div>
                         <button data-index="${index}" class="remove-btn text-gray-400 hover:text-red-500 transition-colors p-1 rounded-full">
@@ -334,9 +319,35 @@
                 });
             }
         }
+        
+        /**
+         * Updates the live formula breakdown view for the current inputs.
+         */
+        function updateLiveBreakdown() {
+            const name = nameInput.value.trim();
+            const tables = parseInt(tablesInput.value, 10);
+            const nodes = parseInt(nodesInput.value, 10);
+
+            if (!name && isNaN(tables) && isNaN(nodes)) {
+                 liveFormulaViewEl.classList.add('hidden');
+                 return;
+            }
+
+            liveFormulaViewEl.classList.remove('hidden');
+            liveUniverseNameEl.textContent = name || "Live Breakdown";
+            
+            if (isNaN(tables) || isNaN(nodes) || tables <= 0 || nodes <= 0) {
+                liveMetricsFormulaEl.textContent = "Please enter valid table and node counts.";
+                return;
+            }
+
+            // This formula is for display purposes only, to show a per-universe calculation
+            const live_metrics = (BigInt(60) * BigInt(tables) + BigInt(9000)) * BigInt(nodes);
+            liveMetricsFormulaEl.innerHTML = `(60 * ${tables.toLocaleString()} + 9000) * ${nodes.toLocaleString()} = <strong class="text-primary-orange">${formatLargeNumber(live_metrics)} metrics</strong>`;
+        }
 
         /**
-         * Handles adding a new universe.
+         * Handles adding a new universe to the list.
          */
         function handleAddUniverse() {
             errorMessage.textContent = '';
@@ -344,26 +355,27 @@
             const tables = parseInt(tablesInput.value, 10);
             const nodes = parseInt(nodesInput.value, 10);
 
-            if (!name || isNaN(tables) || isNaN(nodes) || tables < 0 || nodes < 0) {
-                errorMessage.textContent = 'Please fill in all fields with valid, non-negative numbers.';
+            if (!name || isNaN(tables) || isNaN(nodes) || tables <= 0 || nodes <= 0) {
+                errorMessage.textContent = 'Please fill in all fields with valid, positive numbers.';
                 return;
             }
 
-            const metrics = calculateUniverseMetrics(tables, nodes);
-            universes.push({ name, tables, nodes, metrics });
-
-            renderUniverses();
-            calculateTotalRequirements();
-
+            universes.push({ name, tables, nodes });
+            
+            // Clear input fields
             nameInput.value = '';
             tablesInput.value = '';
             nodesInput.value = '';
+            
             liveFormulaViewEl.classList.add('hidden');
+            renderUniverses();
+            calculateTotalRequirements();
+            
             nameInput.focus();
         }
 
         /**
-         * Handles removing a universe.
+         * Handles removing a universe from the list.
          */
         function handleRemoveUniverse(e) {
             const removeBtn = e.target.closest('.remove-btn');
@@ -374,15 +386,21 @@
                 calculateTotalRequirements();
             }
         }
-
+        
         // --- Event Listeners ---
         addUniverseBtn.addEventListener('click', handleAddUniverse);
         universesList.addEventListener('click', handleRemoveUniverse);
         
-        // Live formula view listeners
-        nameInput.addEventListener('input', updateLiveFormulaView);
-        tablesInput.addEventListener('input', updateLiveFormulaView);
-        nodesInput.addEventListener('input', updateLiveFormulaView);
+        // Listen to input fields for live calculation updates
+        nameInput.addEventListener('input', updateLiveBreakdown);
+        tablesInput.addEventListener('input', () => {
+            calculateTotalRequirements();
+            updateLiveBreakdown();
+        });
+        nodesInput.addEventListener('input', () => {
+            calculateTotalRequirements();
+            updateLiveBreakdown();
+        });
         
         nameInput.addEventListener('keypress', (e) => e.key === 'Enter' && handleAddUniverse());
         tablesInput.addEventListener('keypress', (e) => e.key === 'Enter' && handleAddUniverse());
@@ -395,5 +413,3 @@
 
 </body>
 </html>
-<!-- End of HTML Document -->
-<!-- This document can be used as a standalone HTML file or integrated into a larger web application for YugabyteDB Anywhere, providing users with a powerful tool to estimate their Prometheus resource requirements effectively. -->

--- a/prometheus-sizing-calculator.sh
+++ b/prometheus-sizing-calculator.sh
@@ -1,28 +1,104 @@
 #!/bin/bash
 
-# Usage help
+# This script calculates Prometheus resource estimates based on a consistent, true aggregate model.
+# It sums all tables and nodes first before applying the formula.
+#
+# Usage:
+#   Provide one or more universes using the -u flag.
+#
+# Example:
+#   bash prometheus-sizing-calculator.sh -u 'Universe-1 Name:No of Tables:No of Nodes' -u 'Universe-2 Name:No of Tables:No of Nodes'
+#   bash prometheus-sizing-calculator.sh -u 'Prod:500:3' -u 'Dev:1000:3'
+
+# Function to display messages in bold without prompting for user input
+bold_echo() {
+  if [ "$1" == "-n" ]; then
+    shift
+    echo -ne "\033[1m$@\033[0m"
+  else
+    echo -e "\033[1m$@\033[0m"
+  fi
+}
+
+# Function for prompting user input with bold text without a newline after the prompt
+bold_read() {
+  echo -n -e "\033[1m$1\033[0m "
+  read $2
+}
+
+# About this script:
+echo ""
+echo "- This script interactively estimates memory, disk, and CPU requirements for your YugabyteDB Anywhere node running Prometheus, YB-Platform, and Postgres services."
+echo -n "- For more information, visit: "
+bold_echo "https://support.yugabyte.com/hc/en-us/articles/38092646336909-How-to-Estimate-Prometheus-Resource-Requirements-for-YugabyteDB-Anywhere"
+bold_echo -n "- GitHub"; echo ": https://github.com/yugabyte/yugabyte-prometheus-sizing"
+
+# --- Help ---
 usage() {
-  echo "Usage: $0 -u 'name1:tables1:nodes1' -u 'name2:tables2:nodes2' ..."
   echo ""
-  echo "Each -u flag represents a universe in the format:"
-  echo "  name:tables:nodes"
+  bold_echo "Usage: $0 -u 'Universe-1 Name:No of Tables:No of Nodes' -u 'Universe-2 Name:No of Tables:No of Nodes' ..."
+  echo ""
+  echo "Each -u flag represents a universe in the format: name:tables:nodes"
   echo ""
   echo "Example:"
-  echo "  $0 -u 'Yugabyte-Dev-Cluster:1000:3' -u 'Yugabyte-Dev-Cluster:500:6'"
+  bold_echo "  $0 -u 'Prod:500:3' -u 'Dev:1000:3'"
   exit 1
 }
 
-# Check if bc is installed
+# --- Prerequisite Check ---
 if ! command -v bc &> /dev/null; then
-  echo "This script requires 'bc'. Please install it (e.g., 'sudo apt install bc')."
-  exit 1
+    echo "The 'bc' command is required but not found."
+    
+    # Auto-install prompt
+    read -p "Would you like to try and install it automatically? (y/n) " -n 1 -r
+    echo # Move to a new line
+    if [[ $REPLY =~ ^[Yy]$ ]]; then
+        echo "Attempting to install 'bc'..."
+        
+        # Check for OS type
+        if [[ "$(uname)" == "Linux" ]]; then
+            # Check for common Linux package managers
+            if command -v apt-get &>/dev/null; then
+                sudo apt-get update && sudo apt-get install -y bc
+            elif command -v yum &>/dev/null; then
+                sudo yum install -y bc
+            elif command -v dnf &>/dev/null; then
+                sudo dnf install -y bc
+            else
+                echo "Could not find a supported package manager (apt, yum, dnf). Please install 'bc' manually."
+                exit 1
+            fi
+        elif [[ "$(uname)" == "Darwin" ]]; then
+            # Check for Homebrew on macOS
+            if ! command -v brew &>/dev/null; then
+                echo "Homebrew not found. Please install Homebrew or install 'bc' manually."
+                exit 1
+            fi
+            brew install bc
+        else
+            echo "Unsupported OS. Please install 'bc' manually."
+            exit 1
+        fi
+        
+        # Verify installation after attempting
+        if ! command -v bc &> /dev/null; then
+            echo "Failed to install 'bc'. Please install it manually."
+            exit 1
+        else
+            echo "'bc' has been installed successfully."
+        fi
+    else
+        echo "Please install 'bc' manually to proceed."
+        exit 1
+    fi
 fi
 
-# Initialize
+# --- Initialization ---
 declare -a universes
-total_metrics=0
+total_tables=0
+total_nodes=0
 
-# Parse flags
+# --- Argument Parsing ---
 while getopts ":u:" opt; do
   case $opt in
     u)
@@ -38,7 +114,9 @@ if [ ${#universes[@]} -eq 0 ]; then
   usage
 fi
 
-# Process each universe
+# --- Processing ---
+echo ""
+echo "Processing Universes..."
 for entry in "${universes[@]}"; do
   IFS=':' read -r name tables nodes <<< "$entry"
   if [[ -z "$name" || -z "$tables" || -z "$nodes" ]]; then
@@ -46,20 +124,25 @@ for entry in "${universes[@]}"; do
     usage
   fi
 
-  metrics=$(( (60 * tables + 9000) * nodes ))
-  total_metrics=$(( total_metrics + metrics ))
+  # Sum the total tables and nodes from all universes
+  total_tables=$(( total_tables + tables ))
+  total_nodes=$(( total_nodes + nodes ))
 
-  echo "Universe: $name - Tables: $tables, Nodes: $nodes → Metrics: $metrics"
+  bold_echo "  - Universe: $name - Tables: $tables, Nodes: $nodes"
 done
 
-# Memory per metric
+# --- Calculation ---
+# Apply the main formula ONCE to the aggregated sums
+total_metrics=$(( (60 * total_tables + 9000) * total_nodes ))
+
+# Determine memory factor
 if [ "$total_metrics" -gt 1000000 ]; then
   memory_per_metric=10
 else
   memory_per_metric=30
 fi
 
-# Calculations
+# Calculate final resource needs
 memory_kb=$(( total_metrics * memory_per_metric ))
 memory_gb=$(echo "scale=2; $memory_kb / 1024 / 1024" | bc)
 
@@ -68,10 +151,12 @@ disk_gb=$(echo "scale=2; $disk_kb / 1024 / 1024" | bc)
 
 cpu=$(echo "scale=2; $total_metrics / 1000000" | bc)
 
-# Output summary
+# --- Output ---
 echo ""
-echo "Total Metrics: $total_metrics"
+echo -n "Total Tables: "; bold_echo -n "$total_tables"; echo -n " | Total Nodes: "; bold_echo -n "$total_nodes"; echo
+echo -n "Total Metrics: "; bold_echo "$total_metrics"
+echo ""
 echo "Estimated Requirements:"
-echo "  Memory: $memory_gb GB"
-echo "  Disk:   $disk_gb GB"
-echo "  CPU:    $cpu cores"
+echo -n "  Memory: "; bold_echo "$memory_gb GB"
+echo -n "  Disk:   "; bold_echo "$disk_gb GB"
+echo -n "  CPU:    "; bold_echo "$cpu cores"


### PR DESCRIPTION
…not correct. The core of the issue still remains: the flat + 9000 metrics are being added for each universe you define.

Let's walk through the math with your latest example to see exactly why this is happening.

**Scenario 1: One Large Universe**
Here, we have one entry with the combined tables and nodes.

```
Input: 894 Tables (454 + 440), 6 Nodes

Formula: (60 * Tables * Nodes) + 9000

Calculation: (60 * 894 * 6) + 9000

Breakdown: 321,840 + 9000

Total Metrics: 330,840

```
**Scenario 2: Two Separate Universes**
In this case, the + 9000 overhead gets applied twice, once for each universe.

```
Universe DC (454 Tables, 3 Nodes):

(60 * 454 * 3) + 9000

81,720 + 9000 = 90,720 metrics

Universe DR (440 Tables, 3 Nodes):

(60 * 440 * 3) + 9000

79,200 + 9000 = 88,200 metrics

Total Metrics: 90,720 + 88,200 = 178,920
```

**The Root Cause**
The single large universe results in almost double the metrics (330,840 vs. 178,920) because the per-universe overhead of + 9000 is only applied once. When you create two separate universes, that overhead cost is paid twice.

**The Fix:**

### Formula Explanation

The formula currently used by the calculator determines the metric count for each universe independently:

`Universe Metrics = (60 * Number of Tables + 9000) * Number of Nodes`

Here's what each part means:
* **`60 * Number of Tables`**: This calculates the base metrics generated by the tables themselves.
* **`+ 9000`**: This adds a fixed overhead of 9,000 metrics. This represents the baseline metrics for a universe's infrastructure before scaling.
* **`* Number of Nodes`**: The entire sum (table metrics + overhead) is then multiplied by the number of nodes in that specific universe.

The **Total Deployment Estimate** is simply the sum of the `Universe Metrics` from all the universes you have configured.

***

### Example Calculations

Here is how the formula is applied to your three examples:

#### **Example 1: 1 Table, 1 Node**
* `Metrics = (60 * 1 + 9000) * 1`
* `Metrics = (60 + 9000) * 1`
* `Metrics = 9060 * 1`
* **Result: 9,060 metrics**

---
#### **Example 2: 100 Tables, 1 Node**
* `Metrics = (60 * 100 + 9000) * 1`
* `Metrics = (6000 + 9000) * 1`
* `Metrics = 15000 * 1`
* **Result: 15,000 metrics**

---
#### **Example 3: 100 Tables, 3 Nodes**
* `Metrics = (60 * 100 + 9000) * 3`
* `Metrics = (6000 + 9000) * 3`
* `Metrics = 15000 * 3`
* **Result: 45,000 metrics**

