### PR TITLE
Fixing the calculation logic

### DIFF
--- a/prometheus-sizing-calculator.html
+++ b/prometheus-sizing-calculator.html
@@ -94,12 +94,11 @@
 
                 <!-- Live Formula Breakdown -->
                 <div id="live-formula-view" class="hidden bg-white p-6 rounded-xl shadow-md border border-gray-200">
-                    <h2 id="live-universe-name" class="text-xl font-bold text-primary-orange mb-4">Live Breakdown</h2>
+                    <h2 id="live-universe-name" class="text-xl font-bold text-primary-orange mb-4">Live Preview</h2>
                     <div class="space-y-4 text-sm">
                         <div>
-                            <p class="font-semibold text-gray-800">Isolated Estimate for this Universe</p>
+                            <p class="font-semibold text-gray-800">Metrics from this Universe</p>
                             <p id="live-metrics-formula" class="font-mono text-gray-600 bg-gray-50 p-2 rounded-md mt-1 break-all"></p>
-                            <p class="text-xs text-gray-500 mt-2">Note: This is a preview for this universe alone. The final total on the right uses a combined calculation for higher accuracy.</p>
                         </div>
                     </div>
                 </div>
@@ -172,9 +171,10 @@
                     <!-- Total Metrics Logic -->
                     <div>
                         <h3 class="font-semibold text-primary-orange">Total Metrics</h3>
-                        <p class="text-sm text-gray-600 mt-1 mb-2">Metrics are calculated based on the sum of all tables and nodes across all configured universes to ensure consistency.</p>
+                        <p class="text-sm text-gray-600 mt-1 mb-2">Metrics for each universe are calculated independently and then summed for the final total.</p>
                         <div class="bg-gray-50 border-l-4 border-primary-orange p-4 rounded-md space-y-2">
-                             <code class="block w-full bg-transparent text-gray-800 text-sm font-mono">Total Metrics = (60 * Σ(Tables) + 9000) * Σ(Nodes)</code>
+                             <code class="block w-full bg-transparent text-gray-800 text-sm font-mono">Universe Metrics = (60 * Tables + 9000) * Nodes</code>
+                             <code class="block w-full bg-transparent text-gray-800 text-sm font-mono">Total Metrics = Σ(All Universe Metrics)</code>
                         </div>
                     </div>
 
@@ -258,23 +258,24 @@
         }
         
         /**
-         * Recalculates the total requirements based on the configured universes AND the live inputs.
+         * Calculates metrics for a single universe using the original script's formula.
+         */
+        function calculateUniverseMetrics(tables, nodes) {
+            if (isNaN(tables) || isNaN(nodes) || tables < 0 || nodes < 0) {
+                return BigInt(0);
+            }
+            // Using the formula: (60 * tables + 9000) * nodes
+            return (BigInt(60) * BigInt(tables) + BigInt(9000)) * BigInt(nodes);
+        }
+
+        /**
+         * Recalculates the total requirements based on the configured universes list.
          */
         function calculateTotalRequirements() {
-            // 1. Get totals from the configured universe list
-            let totalTables = universes.reduce((sum, u) => sum + u.tables, 0);
-            let totalNodes = universes.reduce((sum, u) => sum + u.nodes, 0);
-
-            // 2. Add numbers from the live input fields
-            const liveTables = parseInt(tablesInput.value, 10) || 0;
-            const liveNodes = parseInt(nodesInput.value, 10) || 0;
-            totalTables += liveTables;
-            totalNodes += liveNodes;
+            // 1. Sum metrics from all configured universes
+            const total_metrics = universes.reduce((sum, u) => sum + u.metrics, BigInt(0));
             
-            // 3. Apply the final, consistent formula
-            const total_metrics = (BigInt(60) * BigInt(totalTables) + BigInt(9000)) * BigInt(totalNodes);
-            
-            // 4. Calculate final resource requirements
+            // 2. Calculate final resource requirements
             const memory_per_metric = (total_metrics > 1000000) ? BigInt(10) : BigInt(30);
             const memory_kb = total_metrics * memory_per_metric;
             const memory_gb = Number(memory_kb) / 1024 / 1024;
@@ -284,12 +285,34 @@
 
             const cpu = Number(total_metrics) / 1000000;
 
-            // 5. Update the UI
+            // 3. Update the UI
             totalMetricsEl.textContent = formatLargeNumber(total_metrics);
             memoryGbEl.textContent = `${formatLargeNumber(memory_gb, 1e6)} GB`;
             diskGbEl.textContent = `${formatLargeNumber(disk_gb, 1e6)} GB`;
             cpuCoresEl.textContent = `${formatLargeNumber(cpu, 1e6)} Cores`;
         }
+        
+        /**
+         * Updates the live formula view for the current universe being typed.
+         */
+        function updateLiveFormulaView() {
+            const name = nameInput.value.trim();
+            const tables = parseInt(tablesInput.value, 10);
+            const nodes = parseInt(nodesInput.value, 10);
+
+            if (isNaN(tables) || isNaN(nodes) || tables <= 0 || nodes <= 0) {
+                liveFormulaViewEl.classList.add('hidden');
+                return;
+            }
+            
+            liveFormulaViewEl.classList.remove('hidden');
+            liveUniverseNameEl.textContent = name || "Live Preview";
+
+            const live_metrics = calculateUniverseMetrics(tables, nodes);
+            
+            liveMetricsFormulaEl.innerHTML = `(60 * ${tables.toLocaleString()} + 9000) * ${nodes.toLocaleString()} = <strong class="text-primary-orange">${formatLargeNumber(live_metrics)} metrics</strong>`;
+        }
+
 
         /**
          * Renders the list of configured universes in the DOM.
@@ -306,7 +329,7 @@
                         <div>
                             <p class="font-semibold text-gray-800">${universe.name}</p>
                             <p class="text-sm text-gray-600">
-                                Tables: ${universe.tables.toLocaleString()} | Nodes: ${universe.nodes.toLocaleString()}
+                                Tables: ${universe.tables.toLocaleString()} | Nodes: ${universe.nodes.toLocaleString()} → Metrics: <span class="font-medium">${formatLargeNumber(universe.metrics)}</span>
                             </p>
                         </div>
                         <button data-index="${index}" class="remove-btn text-gray-400 hover:text-red-500 transition-colors p-1 rounded-full">
@@ -318,32 +341,6 @@
                     universesList.appendChild(universeEl);
                 });
             }
-        }
-        
-        /**
-         * Updates the live formula breakdown view for the current inputs.
-         */
-        function updateLiveBreakdown() {
-            const name = nameInput.value.trim();
-            const tables = parseInt(tablesInput.value, 10);
-            const nodes = parseInt(nodesInput.value, 10);
-
-            if (!name && isNaN(tables) && isNaN(nodes)) {
-                 liveFormulaViewEl.classList.add('hidden');
-                 return;
-            }
-
-            liveFormulaViewEl.classList.remove('hidden');
-            liveUniverseNameEl.textContent = name || "Live Breakdown";
-            
-            if (isNaN(tables) || isNaN(nodes) || tables <= 0 || nodes <= 0) {
-                liveMetricsFormulaEl.textContent = "Please enter valid table and node counts.";
-                return;
-            }
-
-            // This formula is for display purposes only, to show a per-universe calculation
-            const live_metrics = (BigInt(60) * BigInt(tables) + BigInt(9000)) * BigInt(nodes);
-            liveMetricsFormulaEl.innerHTML = `(60 * ${tables.toLocaleString()} + 9000) * ${nodes.toLocaleString()} = <strong class="text-primary-orange">${formatLargeNumber(live_metrics)} metrics</strong>`;
         }
 
         /**
@@ -360,16 +357,17 @@
                 return;
             }
 
-            universes.push({ name, tables, nodes });
+            const metrics = calculateUniverseMetrics(tables, nodes);
+            universes.push({ name, tables, nodes, metrics });
             
-            // Clear input fields
+            renderUniverses();
+            calculateTotalRequirements();
+            
+            // Clear input fields and hide the live preview
             nameInput.value = '';
             tablesInput.value = '';
             nodesInput.value = '';
-            
             liveFormulaViewEl.classList.add('hidden');
-            renderUniverses();
-            calculateTotalRequirements();
             
             nameInput.focus();
         }
@@ -392,15 +390,9 @@
         universesList.addEventListener('click', handleRemoveUniverse);
         
         // Listen to input fields for live calculation updates
-        nameInput.addEventListener('input', updateLiveBreakdown);
-        tablesInput.addEventListener('input', () => {
-            calculateTotalRequirements();
-            updateLiveBreakdown();
-        });
-        nodesInput.addEventListener('input', () => {
-            calculateTotalRequirements();
-            updateLiveBreakdown();
-        });
+        nameInput.addEventListener('input', updateLiveFormulaView);
+        tablesInput.addEventListener('input', updateLiveFormulaView);
+        nodesInput.addEventListener('input', updateLiveFormulaView);
         
         nameInput.addEventListener('keypress', (e) => e.key === 'Enter' && handleAddUniverse());
         tablesInput.addEventListener('keypress', (e) => e.key === 'Enter' && handleAddUniverse());


### PR DESCRIPTION
Previously it was calculating incorrectly. 

<img width="1134" height="788" alt="Screenshot 2025-08-12 at 11 35 39 AM" src="https://github.com/user-attachments/assets/72c512cd-15e3-4942-9faf-018990c2fd2e" />

However the correct calculation is: 

As per formula: Universe metrics = (60 * Tables + 9000) * Nodes.

Here are the calculations for each universe

```
Prod-1
(60 * 828 Tables + 9000) * 6 Nodes
(49,680 + 9000) * 6
58,680 * 6 = 352,080 metrics
Prod-2
(60 * 2,932 Tables + 9000) * 6 Nodes
(175,920 + 9000) * 6
184,920 * 6 = 1,109,520 metrics
Prod-3
(60 * 2,246 Tables + 9000) * 3 Nodes
(134,760 + 9000) * 3
143,760 * 3 = 431,280 metrics
Prod-4
(60 * 134 Tables + 9000) * 5 Nodes
(8,040 + 9000) * 5
17,040 * 5 = 85,200 metrics
```

So since the total number of metrics is over 1 million, we use the rate of 10 KB per metric.
Calculation: (1,978,080 metrics * 10 KB/metric) / 1024 / 1024
Estimated Memory: ~18.86 GB

<img width="970" height="695" alt="Screenshot 2025-08-12 at 1 38 39 PM" src="https://github.com/user-attachments/assets/d53a6d13-a8d3-4823-9434-8d196c3cc601" />
